### PR TITLE
Fix thread flag handling

### DIFF
--- a/4buttons.py
+++ b/4buttons.py
@@ -10,7 +10,7 @@ import sqlite3
 
 # Variables
 data_base_path = '4buttons.db'
-flag_of_bot = True
+bot.flag_of_bot = True
 con = sqlite3.connect(data_base_path)
 sqlite3.connect(data_base_path, check_same_thread=False)
 
@@ -93,17 +93,17 @@ class mywindow(QtWidgets.QMainWindow):
 
 
     def Thread_1(self):
-        my_thread1 = Mythread()
+        my_thread1 = Mythread(self.ui)
         my_thread1.start()
 
     def stop_function(self):
-        global flag_of_bot
-        flag_of_bot = False
+        bot.flag_of_bot = False
 
 
 class Mythread(Thread):
-    def __init__(self):
-        Thread.__init__(self)
+    def __init__(self, ui):
+        super().__init__()
+        self.ui = ui
 
     def run(self):
         print('Thread is started')

--- a/bot.py
+++ b/bot.py
@@ -3,10 +3,18 @@ import random
 import time
 import sqlite3
 
+# shared flag controlling the generator loop
+flag_of_bot = True
+
 
 def generator_of_shit(con):
-    while True or (flag_of_bot is True):
-        time.sleep((random.randint(0,3)))
-        my_sql_module.insert_sql_table(con, ((random.randint(0,100),(random.randint(0,100)))))
+    """Insert random data until ``flag_of_bot`` becomes ``False``."""
+    global flag_of_bot
+    while flag_of_bot:
+        time.sleep(random.randint(0, 3))
+        my_sql_module.insert_sql_table(
+            con,
+            (random.randint(0, 100), random.randint(0, 100))
+        )
         print('line generated')
-        return my_sql_module.get_line_from_table(con,'all')
+        return my_sql_module.get_line_from_table(con, 'all')


### PR DESCRIPTION
## Summary
- control generator loop via shared flag in `bot.py`
- propagate `bot.flag_of_bot` to UI thread logic
- pass UI instance to thread class

## Testing
- `python -m py_compile bot.py 4buttons.py`

------
https://chatgpt.com/codex/tasks/task_e_685c1bd096d0833286576415dfb13c47